### PR TITLE
修正JSSDK sha1签名计算返回值错误

### DIFF
--- a/api_jssdk_ticket_get_wrap.go
+++ b/api_jssdk_ticket_get_wrap.go
@@ -21,7 +21,7 @@ func (r *JssdkService) GenerateJssdkSignature(ctx context.Context, request *Gene
 	sha1Hash := sha1.New()
 	sha1Hash.Write([]byte(s))
 
-	return fmt.Sprintf("%x", sha1.Sum(nil)), nil
+	return fmt.Sprintf("%x", sha1Hash.Sum(nil)), nil
 }
 
 type GenerateJssdkSignatureReq struct {


### PR DESCRIPTION
* bugfix: 修正JSSDK sha1签名计算返回值错误（issue：https://github.com/chyroc/lark/issues/19）